### PR TITLE
Extend fatal error messaging for bad template tags

### DIFF
--- a/tasks/tags.js
+++ b/tasks/tags.js
@@ -108,7 +108,15 @@ module.exports = function (grunt) {
 
         // verify template tags exist and in logic order
         if (closeTagLocation < openTagLocation || openTagLocation === -1 || closeTagLocation === -1) {
-            grunt.fail.fatal('invalid template tags in ' + fileName);
+            var failPoints;
+            
+            if (openTagLocation === -1 && closeTagLocation === -1) {
+                failPoints = 'Oops: ' + this.options.openTag + '\n' + 'Oops: ' + this.options.closeTag;
+            } else {
+                failPoints = 'Oops: ' + ((openTagLocation === -1) ? this.options.openTag : this.options.closeTag);
+            }
+
+            grunt.fail.fatal('invalid template tag in ' + fileName + '\n'+ failPoints);
         }
     };
 


### PR DESCRIPTION
Just did a quick sketch out for myself once i realized the plugin was just javascript. Quick and dirty, but it works :)

Ref Issue: https://github.com/andrewjmead/grunt-script-link-tags/issues/20